### PR TITLE
chore: update GA key

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,7 +93,7 @@ const config = {
           customCss: require.resolve('./src/css/custom.css'),
         },
         gtag: {
-          trackingID: 'G-BWNQB9CCES',
+          trackingID: 'G-11H450NYS0',
           anonymizeIP: false,
         },
       }),


### PR DESCRIPTION
This pull request (PR) updates the Google Analytics tracking ID to direct it to a newly created project in the Evmos GA dashboard.